### PR TITLE
Require beacon remove event be sent synchronously

### DIFF
--- a/spigot_v1_16_R3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/BukkitAdapter_1_16_5.java
+++ b/spigot_v1_16_R3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/BukkitAdapter_1_16_5.java
@@ -30,6 +30,7 @@ import net.minecraft.server.v1_16_R3.PacketPlayOutLightUpdate;
 import net.minecraft.server.v1_16_R3.PacketPlayOutMapChunk;
 import net.minecraft.server.v1_16_R3.PlayerChunk;
 import net.minecraft.server.v1_16_R3.PlayerChunkMap;
+import net.minecraft.server.v1_16_R3.TileEntity;
 import net.minecraft.server.v1_16_R3.World;
 import net.minecraft.server.v1_16_R3.WorldServer;
 import org.bukkit.craftbukkit.v1_16_R3.CraftChunk;
@@ -72,6 +73,8 @@ public final class BukkitAdapter_1_16_5 extends NMSAdapter {
     private static final Field fieldLock;
     private static final long fieldLockOffset;
 
+    private static final Field fieldTileEntityRemoved;
+
     static {
         try {
             fieldSize = DataPaletteBlock.class.getDeclaredField("i");
@@ -101,6 +104,9 @@ public final class BukkitAdapter_1_16_5 extends NMSAdapter {
             Unsafe unsafe = UnsafeUtility.getUNSAFE();
             fieldLock = DataPaletteBlock.class.getDeclaredField("j");
             fieldLockOffset = unsafe.objectFieldOffset(fieldLock);
+
+            fieldTileEntityRemoved = TileEntity.class.getDeclaredField("f");
+            fieldTileEntityRemoved.setAccessible(true);
 
             CHUNKSECTION_BASE = unsafe.arrayBaseOffset(ChunkSection[].class);
             int scale = unsafe.arrayIndexScale(ChunkSection[].class);
@@ -305,6 +311,18 @@ public final class BukkitAdapter_1_16_5 extends NMSAdapter {
         } catch (IllegalAccessException e) {
             e.printStackTrace();
             return null;
+        }
+    }
+
+    protected static void removeBeacon(TileEntity beacon, Chunk nmsChunk) {
+        try {
+            // Do the method ourselves to avoid trying to reflect generic method parameters
+            if (nmsChunk.loaded || nmsChunk.world.s_()) {
+                nmsChunk.tileEntities.remove(beacon.getPosition());
+            }
+            fieldTileEntityRemoved.set(beacon, true);
+        } catch (Throwable throwable) {
+            throwable.printStackTrace();
         }
     }
 }

--- a/spigot_v1_16_R3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/BukkitGetBlocks_1_16_5.java
+++ b/spigot_v1_16_R3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/BukkitGetBlocks_1_16_5.java
@@ -28,6 +28,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockTypes;
 import io.papermc.lib.PaperLib;
+import io.papermc.paper.event.block.BeaconDeactivatedEvent;
 import net.minecraft.server.v1_16_R3.BiomeBase;
 import net.minecraft.server.v1_16_R3.BiomeStorage;
 import net.minecraft.server.v1_16_R3.BlockPosition;
@@ -49,7 +50,9 @@ import net.minecraft.server.v1_16_R3.NBTTagCompound;
 import net.minecraft.server.v1_16_R3.NBTTagInt;
 import net.minecraft.server.v1_16_R3.NibbleArray;
 import net.minecraft.server.v1_16_R3.SectionPosition;
+import net.minecraft.server.v1_16_R3.SoundEffects;
 import net.minecraft.server.v1_16_R3.TileEntity;
+import net.minecraft.server.v1_16_R3.TileEntityBeacon;
 import net.minecraft.server.v1_16_R3.WorldServer;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.World;
@@ -61,6 +64,7 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 import java.util.AbstractSet;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -388,28 +392,34 @@ public class BukkitGetBlocks_1_16_5 extends CharGetBlocks implements BukkitGetBl
             Chunk nmsChunk = ensureLoaded(nmsWorld, chunkX, chunkZ);
             boolean fastmode = set.isFastMode() && Settings.IMP.QUEUE.NO_TICK_FASTMODE;
 
-            // Remove existing tiles
-            {
-                // Create a copy so that we can remove blocks
-                Map<BlockPosition, TileEntity> tiles = new HashMap<>(nmsChunk.getTileEntities());
-                if (!tiles.isEmpty()) {
-                    for (Map.Entry<BlockPosition, TileEntity> entry : tiles.entrySet()) {
-                        final BlockPosition pos = entry.getKey();
-                        final int lx = pos.getX() & 15;
-                        final int ly = pos.getY();
-                        final int lz = pos.getZ() & 15;
-                        final int layer = ly >> 4;
-                        if (!set.hasSection(layer)) {
+            // Remove existing tiles. Create a copy so that we can remove blocks
+            Map<BlockPosition, TileEntity> chunkTiles = new HashMap<>(nmsChunk.getTileEntities());
+            List<TileEntity> beacons = null;
+            if (!chunkTiles.isEmpty()) {
+                for (Map.Entry<BlockPosition, TileEntity> entry : chunkTiles.entrySet()) {
+                    final BlockPosition pos = entry.getKey();
+                    final int lx = pos.getX() & 15;
+                    final int ly = pos.getY();
+                    final int lz = pos.getZ() & 15;
+                    final int layer = ly >> 4;
+                    if (!set.hasSection(layer)) {
+                        continue;
+                    }
+
+                    int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
+                    if (ordinal != 0) {
+                        TileEntity tile = entry.getValue();
+                        if (tile instanceof TileEntityBeacon) {
+                            if (beacons == null) {
+                                beacons = new ArrayList<>();
+                            }
+                            beacons.add(tile);
+                            BukkitAdapter_1_16_5.removeBeacon(tile, nmsChunk);
                             continue;
                         }
-
-                        int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
-                        if (ordinal != 0) {
-                            TileEntity tile = entry.getValue();
-                            nmsChunk.removeTileEntity(tile.getPosition());
-                            if (createCopy) {
-                                copy.storeTile(tile);
-                            }
+                        nmsChunk.removeTileEntity(tile.getPosition());
+                        if (createCopy) {
+                            copy.storeTile(tile);
                         }
                     }
                 }
@@ -518,9 +528,25 @@ public class BukkitGetBlocks_1_16_5 extends CharGetBlocks implements BukkitGetBl
                 int bx = chunkX << 4;
                 int bz = chunkZ << 4;
 
+                // Call beacon deactivate events here synchronously
+                if (beacons != null && !beacons.isEmpty()) {
+                    final List<TileEntity> finalBeacons = beacons;
+
+                    syncTasks = new Runnable[4];
+
+                    syncTasks[3] = () -> {
+                        for (TileEntity beacon : finalBeacons) {
+                            ((TileEntityBeacon) beacon).a(SoundEffects.BLOCK_BEACON_DEACTIVATE);
+                            new BeaconDeactivatedEvent(CraftBlock.at(beacon.getWorld(), beacon.getPosition())).callEvent();
+                        }
+                    };
+                }
+
                 Set<UUID> entityRemoves = set.getEntityRemoves();
                 if (entityRemoves != null && !entityRemoves.isEmpty()) {
-                    syncTasks = new Runnable[3];
+                    if (syncTasks == null) {
+                        syncTasks = new Runnable[3];
+                    }
 
                     syncTasks[2] = () -> {
                         final List<Entity>[] entities = nmsChunk.getEntitySlices();

--- a/spigot_v1_16_R3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/BukkitGetBlocks_1_16_5.java
+++ b/spigot_v1_16_R3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/BukkitGetBlocks_1_16_5.java
@@ -409,7 +409,7 @@ public class BukkitGetBlocks_1_16_5 extends CharGetBlocks implements BukkitGetBl
                     int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
                     if (ordinal != 0) {
                         TileEntity tile = entry.getValue();
-                        if (tile instanceof TileEntityBeacon) {
+                        if (PaperLib.isPaper() && tile instanceof TileEntityBeacon) {
                             if (beacons == null) {
                                 beacons = new ArrayList<>();
                             }
@@ -529,6 +529,7 @@ public class BukkitGetBlocks_1_16_5 extends CharGetBlocks implements BukkitGetBl
                 int bz = chunkZ << 4;
 
                 // Call beacon deactivate events here synchronously
+                // list will be null on spigot, so this is an implicit isPaper check
                 if (beacons != null && !beacons.isEmpty()) {
                     final List<TileEntity> finalBeacons = beacons;
 

--- a/spigot_v1_17_R1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/BukkitGetBlocks_1_17.java
+++ b/spigot_v1_17_R1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/BukkitGetBlocks_1_17.java
@@ -411,7 +411,7 @@ public class BukkitGetBlocks_1_17 extends CharGetBlocks implements BukkitGetBloc
                     int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
                     if (ordinal != 0) {
                         TileEntity tile = entry.getValue();
-                        if (tile instanceof TileEntityBeacon) {
+                        if (PaperLib.isPaper() && tile instanceof TileEntityBeacon) {
                             if (beacons == null) {
                                 beacons = new ArrayList<>();
                             }
@@ -531,6 +531,7 @@ public class BukkitGetBlocks_1_17 extends CharGetBlocks implements BukkitGetBloc
                 int bz = chunkZ << 4;
 
                 // Call beacon deactivate events here synchronously
+                // list will be null on spigot, so this is an implicit isPaper check
                 if (beacons != null && !beacons.isEmpty()) {
                     final List<TileEntity> finalBeacons = beacons;
 

--- a/spigot_v1_17_R1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/BukkitGetBlocks_1_17.java
+++ b/spigot_v1_17_R1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/BukkitGetBlocks_1_17.java
@@ -28,18 +28,21 @@ import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockTypes;
+import io.papermc.paper.event.block.BeaconDeactivatedEvent;
 import net.minecraft.core.BlockPosition;
 import net.minecraft.core.IRegistry;
 import net.minecraft.core.SectionPosition;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagInt;
 import net.minecraft.server.level.WorldServer;
+import net.minecraft.sounds.SoundEffects;
 import net.minecraft.util.DataBits;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityTypes;
 import net.minecraft.world.level.EnumSkyBlock;
 import net.minecraft.world.level.biome.BiomeBase;
 import net.minecraft.world.level.block.entity.TileEntity;
+import net.minecraft.world.level.block.entity.TileEntityBeacon;
 import net.minecraft.world.level.block.state.IBlockData;
 import net.minecraft.world.level.chunk.BiomeStorage;
 import net.minecraft.world.level.chunk.Chunk;
@@ -61,6 +64,7 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 import java.util.AbstractSet;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -390,28 +394,34 @@ public class BukkitGetBlocks_1_17 extends CharGetBlocks implements BukkitGetBloc
             Chunk nmsChunk = ensureLoaded(nmsWorld, chunkX, chunkZ);
             boolean fastmode = set.isFastMode() && Settings.IMP.QUEUE.NO_TICK_FASTMODE;
 
-            // Remove existing tiles
-            {
-                // Create a copy so that we can remove blocks
-                Map<BlockPosition, TileEntity> tiles = new HashMap<>(nmsChunk.getTileEntities());
-                if (!tiles.isEmpty()) {
-                    for (Map.Entry<BlockPosition, TileEntity> entry : tiles.entrySet()) {
-                        final BlockPosition pos = entry.getKey();
-                        final int lx = pos.getX() & 15;
-                        final int ly = pos.getY();
-                        final int lz = pos.getZ() & 15;
-                        final int layer = ly >> 4;
-                        if (!set.hasSection(layer)) {
+            // Remove existing tiles. Create a copy so that we can remove blocks
+            Map<BlockPosition, TileEntity> chunkTiles = new HashMap<>(nmsChunk.getTileEntities());
+            List<TileEntity> beacons = null;
+            if (!chunkTiles.isEmpty()) {
+                for (Map.Entry<BlockPosition, TileEntity> entry : chunkTiles.entrySet()) {
+                    final BlockPosition pos = entry.getKey();
+                    final int lx = pos.getX() & 15;
+                    final int ly = pos.getY();
+                    final int lz = pos.getZ() & 15;
+                    final int layer = ly >> 4;
+                    if (!set.hasSection(layer)) {
+                        continue;
+                    }
+
+                    int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
+                    if (ordinal != 0) {
+                        TileEntity tile = entry.getValue();
+                        if (tile instanceof TileEntityBeacon) {
+                            if (beacons == null) {
+                                beacons = new ArrayList<>();
+                            }
+                            beacons.add(tile);
+                            BukkitAdapter_1_17.removeBeacon(tile, nmsChunk);
                             continue;
                         }
-
-                        int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
-                        if (ordinal != 0) {
-                            TileEntity tile = entry.getValue();
-                            nmsChunk.removeTileEntity(tile.getPosition());
-                            if (createCopy) {
-                                copy.storeTile(tile);
-                            }
+                        nmsChunk.removeTileEntity(tile.getPosition());
+                        if (createCopy) {
+                            copy.storeTile(tile);
                         }
                     }
                 }
@@ -520,9 +530,25 @@ public class BukkitGetBlocks_1_17 extends CharGetBlocks implements BukkitGetBloc
                 int bx = chunkX << 4;
                 int bz = chunkZ << 4;
 
+                // Call beacon deactivate events here synchronously
+                if (beacons != null && !beacons.isEmpty()) {
+                    final List<TileEntity> finalBeacons = beacons;
+
+                    syncTasks = new Runnable[4];
+
+                    syncTasks[3] = () -> {
+                        for (TileEntity beacon : finalBeacons) {
+                            TileEntityBeacon.a(beacon.getWorld(), beacon.getPosition(), SoundEffects.ba);
+                            new BeaconDeactivatedEvent(CraftBlock.at(beacon.getWorld(), beacon.getPosition())).callEvent();
+                        }
+                    };
+                }
+
                 Set<UUID> entityRemoves = set.getEntityRemoves();
                 if (entityRemoves != null && !entityRemoves.isEmpty()) {
-                    syncTasks = new Runnable[3];
+                    if (syncTasks == null) {
+                        syncTasks = new Runnable[3];
+                    }
 
                     syncTasks[2] = () -> {
                         final List<Entity>[] entities = /*nmsChunk.e()*/ new List[0];

--- a/spigot_v1_17_R1_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/BukkitAdapter_1_17_1.java
+++ b/spigot_v1_17_R1_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/BukkitAdapter_1_17_1.java
@@ -14,6 +14,9 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import io.papermc.lib.PaperLib;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import net.minecraft.core.BlockPosition;
+import net.minecraft.core.SectionPosition;
 import net.minecraft.nbt.GameProfileSerializer;
 import net.minecraft.network.protocol.game.PacketPlayOutLightUpdate;
 import net.minecraft.network.protocol.game.PacketPlayOutMapChunk;
@@ -26,6 +29,8 @@ import net.minecraft.world.level.ChunkCoordIntPair;
 import net.minecraft.world.level.World;
 import net.minecraft.world.level.biome.BiomeBase;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.ITileEntity;
+import net.minecraft.world.level.block.entity.TileEntity;
 import net.minecraft.world.level.block.state.IBlockData;
 import net.minecraft.world.level.chunk.BiomeStorage;
 import net.minecraft.world.level.chunk.Chunk;
@@ -33,6 +38,8 @@ import net.minecraft.world.level.chunk.ChunkSection;
 import net.minecraft.world.level.chunk.DataPalette;
 import net.minecraft.world.level.chunk.DataPaletteBlock;
 import net.minecraft.world.level.chunk.DataPaletteLinear;
+import net.minecraft.world.level.gameevent.GameEventDispatcher;
+import net.minecraft.world.level.gameevent.GameEventListener;
 import org.bukkit.craftbukkit.v1_17_R1.CraftChunk;
 import org.bukkit.craftbukkit.v1_17_R1.CraftWorld;
 import sun.misc.Unsafe;
@@ -74,6 +81,11 @@ public final class BukkitAdapter_1_17_1 extends NMSAdapter {
     private static final Field fieldLock;
     private static final long fieldLockOffset;
 
+    private static final Field fieldEventDispatcherMap;
+    private static final MethodHandle methodremoveTickingBlockEntity;
+
+    private static final Field fieldTileEntityRemoved;
+
     static {
         try {
             // TODO
@@ -104,6 +116,15 @@ public final class BukkitAdapter_1_17_1 extends NMSAdapter {
             Unsafe unsafe = UnsafeUtility.getUNSAFE();
             fieldLock = DataPaletteBlock.class.getDeclaredField("m");
             fieldLockOffset = unsafe.objectFieldOffset(fieldLock);
+
+            fieldEventDispatcherMap = Chunk.class.getDeclaredField("x");
+            fieldEventDispatcherMap.setAccessible(true);
+            Method removeTickingBlockEntity = Chunk.class.getDeclaredMethod("l", BlockPosition.class);
+            removeTickingBlockEntity.setAccessible(true);
+            methodremoveTickingBlockEntity = MethodHandles.lookup().unreflect(removeTickingBlockEntity);
+
+            fieldTileEntityRemoved = TileEntity.class.getDeclaredField("p");
+            fieldTileEntityRemoved.setAccessible(true);
 
             CHUNKSECTION_BASE = unsafe.arrayBaseOffset(ChunkSection[].class);
             int scale = unsafe.arrayIndexScale(ChunkSection[].class);
@@ -313,6 +334,40 @@ public final class BukkitAdapter_1_17_1 extends NMSAdapter {
         } catch (IllegalAccessException e) {
             e.printStackTrace();
             return null;
+        }
+    }
+
+    protected static void removeBeacon(TileEntity beacon, Chunk nmsChunk) {
+        try {
+            // Do the method ourselves to avoid trying to reflect generic method parameters
+            if (nmsChunk.h || nmsChunk.i.isClientSide()) {
+                TileEntity tileentity = nmsChunk.l.remove(beacon.getPosition());
+                if (tileentity != null) {
+                    if (!nmsChunk.i.y) {
+                        Block block = beacon.getBlock().getBlock();
+                        if (block instanceof ITileEntity) {
+                            GameEventListener gameeventlistener = ((ITileEntity) block).a(nmsChunk.i, beacon);
+                            if (gameeventlistener != null) {
+                                int i = SectionPosition.a(beacon.getPosition().getY());
+                                GameEventDispatcher gameeventdispatcher = nmsChunk.a(i);
+                                gameeventdispatcher.b(gameeventlistener);
+                                if (gameeventdispatcher.a()) {
+                                    try {
+                                        ((Int2ObjectMap<GameEventDispatcher>) fieldEventDispatcherMap.get(nmsChunk))
+                                            .remove(i);
+                                    } catch (IllegalAccessException e) {
+                                        e.printStackTrace();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    fieldTileEntityRemoved.set(beacon, true);
+                }
+            }
+            methodremoveTickingBlockEntity.invoke(nmsChunk, beacon.getPosition());
+        } catch (Throwable throwable) {
+            throwable.printStackTrace();
         }
     }
 }

--- a/spigot_v1_17_R1_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/BukkitGetBlocks_1_17_1.java
+++ b/spigot_v1_17_R1_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/BukkitGetBlocks_1_17_1.java
@@ -28,18 +28,21 @@ import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockTypes;
+import io.papermc.paper.event.block.BeaconDeactivatedEvent;
 import net.minecraft.core.BlockPosition;
 import net.minecraft.core.IRegistry;
 import net.minecraft.core.SectionPosition;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagInt;
 import net.minecraft.server.level.WorldServer;
+import net.minecraft.sounds.SoundEffects;
 import net.minecraft.util.DataBits;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityTypes;
 import net.minecraft.world.level.EnumSkyBlock;
 import net.minecraft.world.level.biome.BiomeBase;
 import net.minecraft.world.level.block.entity.TileEntity;
+import net.minecraft.world.level.block.entity.TileEntityBeacon;
 import net.minecraft.world.level.block.state.IBlockData;
 import net.minecraft.world.level.chunk.BiomeStorage;
 import net.minecraft.world.level.chunk.Chunk;
@@ -61,6 +64,7 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 import java.util.AbstractSet;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -390,28 +394,34 @@ public class BukkitGetBlocks_1_17_1 extends CharGetBlocks implements BukkitGetBl
             Chunk nmsChunk = ensureLoaded(nmsWorld, chunkX, chunkZ);
             boolean fastmode = set.isFastMode() && Settings.IMP.QUEUE.NO_TICK_FASTMODE;
 
-            // Remove existing tiles
-            {
-                // Create a copy so that we can remove blocks
-                Map<BlockPosition, TileEntity> tiles = new HashMap<>(nmsChunk.getTileEntities());
-                if (!tiles.isEmpty()) {
-                    for (Map.Entry<BlockPosition, TileEntity> entry : tiles.entrySet()) {
-                        final BlockPosition pos = entry.getKey();
-                        final int lx = pos.getX() & 15;
-                        final int ly = pos.getY();
-                        final int lz = pos.getZ() & 15;
-                        final int layer = ly >> 4;
-                        if (!set.hasSection(layer)) {
+            // Remove existing tiles. Create a copy so that we can remove blocks
+            Map<BlockPosition, TileEntity> chunkTiles = new HashMap<>(nmsChunk.getTileEntities());
+            List<TileEntity> beacons = null;
+            if (!chunkTiles.isEmpty()) {
+                for (Map.Entry<BlockPosition, TileEntity> entry : chunkTiles.entrySet()) {
+                    final BlockPosition pos = entry.getKey();
+                    final int lx = pos.getX() & 15;
+                    final int ly = pos.getY();
+                    final int lz = pos.getZ() & 15;
+                    final int layer = ly >> 4;
+                    if (!set.hasSection(layer)) {
+                        continue;
+                    }
+
+                    int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
+                    if (ordinal != 0) {
+                        TileEntity tile = entry.getValue();
+                        if (tile instanceof TileEntityBeacon) {
+                            if (beacons == null) {
+                                beacons = new ArrayList<>();
+                            }
+                            beacons.add(tile);
+                            BukkitAdapter_1_17_1.removeBeacon(tile, nmsChunk);
                             continue;
                         }
-
-                        int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
-                        if (ordinal != 0) {
-                            TileEntity tile = entry.getValue();
-                            nmsChunk.removeTileEntity(tile.getPosition());
-                            if (createCopy) {
-                                copy.storeTile(tile);
-                            }
+                        nmsChunk.removeTileEntity(tile.getPosition());
+                        if (createCopy) {
+                            copy.storeTile(tile);
                         }
                     }
                 }
@@ -520,9 +530,25 @@ public class BukkitGetBlocks_1_17_1 extends CharGetBlocks implements BukkitGetBl
                 int bx = chunkX << 4;
                 int bz = chunkZ << 4;
 
+                // Call beacon deactivate events here synchronously
+                if (beacons != null && !beacons.isEmpty()) {
+                    final List<TileEntity> finalBeacons = beacons;
+
+                    syncTasks = new Runnable[4];
+
+                    syncTasks[3] = () -> {
+                        for (TileEntity beacon : finalBeacons) {
+                            TileEntityBeacon.a(beacon.getWorld(), beacon.getPosition(), SoundEffects.ba);
+                            new BeaconDeactivatedEvent(CraftBlock.at(beacon.getWorld(), beacon.getPosition())).callEvent();
+                        }
+                    };
+                }
+
                 Set<UUID> entityRemoves = set.getEntityRemoves();
                 if (entityRemoves != null && !entityRemoves.isEmpty()) {
-                    syncTasks = new Runnable[3];
+                    if (syncTasks == null) {
+                        syncTasks = new Runnable[3];
+                    }
 
                     syncTasks[2] = () -> {
                         final List<Entity>[] entities = /*nmsChunk.e()*/ new List[0];

--- a/spigot_v1_17_R1_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/BukkitGetBlocks_1_17_1.java
+++ b/spigot_v1_17_R1_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/BukkitGetBlocks_1_17_1.java
@@ -411,7 +411,7 @@ public class BukkitGetBlocks_1_17_1 extends CharGetBlocks implements BukkitGetBl
                     int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
                     if (ordinal != 0) {
                         TileEntity tile = entry.getValue();
-                        if (tile instanceof TileEntityBeacon) {
+                        if (PaperLib.isPaper() && tile instanceof TileEntityBeacon) {
                             if (beacons == null) {
                                 beacons = new ArrayList<>();
                             }
@@ -531,6 +531,7 @@ public class BukkitGetBlocks_1_17_1 extends CharGetBlocks implements BukkitGetBl
                 int bz = chunkZ << 4;
 
                 // Call beacon deactivate events here synchronously
+                // list will be null on spigot, so this is an implicit isPaper check
                 if (beacons != null && !beacons.isEmpty()) {
                     final List<TileEntity> finalBeacons = beacons;
 


### PR DESCRIPTION
We should still be removing beacons before we conduct the edit to the chunk, so must do some of the work ourselves and then fire the event/sound synchronously at the end (when players would know about it).

Fixes IntellectualSites/FastAsyncWorldEdit#1048