### PR TITLE
remove vanilla biome restriction

### DIFF
--- a/spigot_v1_16_R3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/FAWE_Spigot_v1_16_R3.java
+++ b/spigot_v1_16_R3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/FAWE_Spigot_v1_16_R3.java
@@ -602,11 +602,22 @@ public final class FAWE_Spigot_v1_16_R3 extends CachedBukkitAdapter implements I
 
     @Override
     public int getInternalBiomeId(BiomeType biome) {
-        BiomeBase base = CraftBlock.biomeToBiomeBase(
-                MinecraftServer.getServer().getCustomRegistry().b(IRegistry.ay),
-                BukkitAdapter.adapt(biome)
-        );
-        return MinecraftServer.getServer().getCustomRegistry().b(IRegistry.ay).a(base);
+        if (biome.getId().startsWith("minecraft:")) {
+            BiomeBase base = CraftBlock.biomeToBiomeBase(
+                    MinecraftServer.getServer().getCustomRegistry().b(IRegistry.ay),
+                    BukkitAdapter.adapt(biome)
+            );
+            return MinecraftServer.getServer().getCustomRegistry().b(IRegistry.ay).a(base);
+        } else {
+            IRegistryWritable<BiomeBase> biomeRegistry = MinecraftServer.getServer().getCustomRegistry()
+                    .b(IRegistry.ay);
+
+            MinecraftKey resourceLocation = biomeRegistry.keySet().stream()
+                    .filter(resource -> resource.toString().equals(biome.getId()))
+                    .findAny().orElse(null);
+
+            return biomeRegistry.a(biomeRegistry.get(resourceLocation));
+        }
     }
 
     @Override

--- a/spigot_v1_17_R1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/FAWE_Spigot_v1_17_R1.java
+++ b/spigot_v1_17_R1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/FAWE_Spigot_v1_17_R1.java
@@ -73,6 +73,7 @@ import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.core.BlockPosition;
 import net.minecraft.core.IRegistry;
 import net.minecraft.core.IRegistryWritable;
+import net.minecraft.core.Registry;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagInt;
@@ -623,11 +624,22 @@ public final class FAWE_Spigot_v1_17_R1 extends CachedBukkitAdapter implements I
 
     @Override
     public int getInternalBiomeId(BiomeType biome) {
-        BiomeBase base = CraftBlock.biomeToBiomeBase(
-                MinecraftServer.getServer().getCustomRegistry().b(IRegistry.aO),
-                BukkitAdapter.adapt(biome)
-        );
-        return MinecraftServer.getServer().getCustomRegistry().b(IRegistry.aO).getId(base);
+        if (biome.getId().startsWith("minecraft:")) {
+            BiomeBase base = CraftBlock.biomeToBiomeBase(
+                    MinecraftServer.getServer().getCustomRegistry().b(IRegistry.aO),
+                    BukkitAdapter.adapt(biome)
+            );
+            return MinecraftServer.getServer().getCustomRegistry().b(IRegistry.aO).getId(base);
+        } else {
+            IRegistryWritable<BiomeBase> biomeRegistry = MinecraftServer.getServer().getCustomRegistry()
+                    .b(IRegistry.aO);
+
+            MinecraftKey resourceLocation = biomeRegistry.keySet().stream()
+                    .filter(resource -> resource.toString().equals(biome.getId()))
+                    .findAny().orElse(null);
+
+            return biomeRegistry.getId(biomeRegistry.get(resourceLocation));
+        }
     }
 
     @Override


### PR DESCRIPTION
## Description
Removing the restriction for biomes to use the minecraft: namespace, allowing the use of custom biomes. This already works, but it seems to only work for one custom biome per new namespace. Thats why I removed this restriction in this PR.

## Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] I tested my changes and approved their functionality.
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)