### PR TITLE
Update populator handling in favor of FastAsyncWorldEdit/pull/1376

### DIFF
--- a/spigot_v1_15_R2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/regen/Regen_v1_15_R2.java
+++ b/spigot_v1_15_R2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/regen/Regen_v1_15_R2.java
@@ -4,6 +4,7 @@ import com.fastasyncworldedit.bukkit.adapter.Regenerator;
 import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.queue.IChunkCache;
 import com.fastasyncworldedit.core.queue.IChunkGet;
+import com.fastasyncworldedit.core.util.TaskManager;
 import com.google.common.collect.ImmutableSet;
 import com.mojang.datafixers.util.Either;
 import com.sk89q.worldedit.bukkit.adapter.impl.fawe.BukkitGetBlocks_1_15_2;
@@ -292,7 +293,7 @@ public class Regen_v1_15_R2 extends Regenerator<IChunkAccess, ProtoChunk, Chunk,
             // redirect to our protoChunks list
             @Override
             public IChunkAccess getChunkAt(int x, int z, ChunkStatus chunkstatus, boolean flag) {
-                return getProtoChunkAt(x, z);
+                return Regen_v1_15_R2.this.getChunkAt(x, z);
             }
         };
         chunkProviderField.set(freshNMSWorld, freshChunkProvider);
@@ -357,7 +358,7 @@ public class Regen_v1_15_R2 extends Regenerator<IChunkAccess, ProtoChunk, Chunk,
 
     @Override
     protected void populate(Chunk chunk, Random random, BlockPopulator pop) {
-        pop.populate(freshNMSWorld.getWorld(), random, chunk.bukkitChunk);
+        TaskManager.IMP.task(() -> pop.populate(freshNMSWorld.getWorld(), random, chunk.bukkitChunk));
     }
 
     @Override

--- a/spigot_v1_16_R3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/regen/Regen_v1_16_R3.java
+++ b/spigot_v1_16_R3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/regen/Regen_v1_16_R3.java
@@ -4,6 +4,7 @@ import com.fastasyncworldedit.bukkit.adapter.Regenerator;
 import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.queue.IChunkCache;
 import com.fastasyncworldedit.core.queue.IChunkGet;
+import com.fastasyncworldedit.core.util.TaskManager;
 import com.google.common.collect.ImmutableList;
 import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
@@ -311,7 +312,7 @@ public class Regen_v1_16_R3 extends Regenerator<IChunkAccess, ProtoChunk, Chunk,
             // redirect to our protoChunks list
             @Override
             public IChunkAccess getChunkAt(int x, int z, ChunkStatus chunkstatus, boolean flag) {
-                return getProtoChunkAt(x, z);
+                return Regen_v1_16_R3.this.getChunkAt(x, z);
             }
         };
         chunkProviderField.set(freshNMSWorld, freshChunkProvider);
@@ -389,7 +390,7 @@ public class Regen_v1_16_R3 extends Regenerator<IChunkAccess, ProtoChunk, Chunk,
 
     @Override
     protected void populate(Chunk chunk, Random random, BlockPopulator pop) {
-        pop.populate(freshNMSWorld.getWorld(), random, chunk.bukkitChunk);
+        TaskManager.IMP.task(() -> pop.populate(freshNMSWorld.getWorld(), random, chunk.bukkitChunk));
     }
 
     @Override

--- a/spigot_v1_17_R1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/regen/Regen_v1_17_R1.java
+++ b/spigot_v1_17_R1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/regen/Regen_v1_17_R1.java
@@ -4,6 +4,7 @@ import com.fastasyncworldedit.bukkit.adapter.Regenerator;
 import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.queue.IChunkCache;
 import com.fastasyncworldedit.core.queue.IChunkGet;
+import com.fastasyncworldedit.core.util.TaskManager;
 import com.google.common.collect.ImmutableList;
 import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
@@ -305,7 +306,7 @@ public class Regen_v1_17_R1 extends Regenerator<IChunkAccess, ProtoChunk, Chunk,
             // redirect to our protoChunks list
             @Override
             public IChunkAccess getChunkAt(int x, int z, ChunkStatus chunkstatus, boolean flag) {
-                return getProtoChunkAt(x, z);
+                return Regen_v1_17_R1.this.getChunkAt(x, z);
             }
         };
         chunkProviderField.set(freshNMSWorld, freshChunkProvider);
@@ -387,7 +388,7 @@ public class Regen_v1_17_R1 extends Regenerator<IChunkAccess, ProtoChunk, Chunk,
 
     @Override
     protected void populate(Chunk chunk, Random random, BlockPopulator pop) {
-        pop.populate(freshNMSWorld.getWorld(), random, chunk.bukkitChunk);
+        TaskManager.IMP.task(() -> pop.populate(freshNMSWorld.getWorld(), random, chunk.bukkitChunk));
     }
 
     @Override


### PR DESCRIPTION
## Overview
Fixes regen functionality with custom block populators

## Description
See https://github.com/IntellectualSites/FastAsyncWorldEdit/pull/1376

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)