### PR TITLE
Use chunk section coordinate for max section coordinate

### DIFF
--- a/spigot_v1_15_R2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/BukkitGetBlocks_1_15_2.java
+++ b/spigot_v1_15_R2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/BukkitGetBlocks_1_15_2.java
@@ -100,7 +100,7 @@ public class BukkitGetBlocks_1_15_2 extends CharGetBlocks implements BukkitGetBl
     }
 
     public BukkitGetBlocks_1_15_2(WorldServer world, int chunkX, int chunkZ) {
-        super(0, 255);
+        super(0, 15);
         this.world = world;
         this.chunkX = chunkX;
         this.chunkZ = chunkZ;

--- a/spigot_v1_16_R3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/BukkitGetBlocks_1_16_5.java
+++ b/spigot_v1_16_R3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/BukkitGetBlocks_1_16_5.java
@@ -105,7 +105,7 @@ public class BukkitGetBlocks_1_16_5 extends CharGetBlocks implements BukkitGetBl
     }
 
     public BukkitGetBlocks_1_16_5(WorldServer world, int chunkX, int chunkZ) {
-        super(0, 255);
+        super(0, 15);
         this.world = world;
         this.chunkX = chunkX;
         this.chunkZ = chunkZ;


### PR DESCRIPTION
## Overview
Fixes https://github.com/IntellectualSites/FastAsyncWorldEdit/issues/1386

## Description
Update the CharGetBlocks implementation to use the max chunk section coordinate instead of the max y coordinate.

## Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)