### PR TITLE
Don't bundle 1.15.2 adapters anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
-<h1>
-    <img src="https://github.com/EngineHub/WorldEdit/raw/master/worldedit-logo.svg" alt="WorldEdit" width="400" />
-</h1>
-
-This repository is for adapter classes used by WorldEdit to work with
+This repository is for adapter classes used by FastAsyncWorldEdit to work with
 various platforms.
 
-WorldEdit is open source and available under the GNU Lesser General Public
+FastAsyncWorldEdit is open source and available under the GNU Lesser General Public
 License v3.
 
 Contributing
@@ -15,8 +11,3 @@ We happily accept contributions, especially through pull requests on GitHub.
 Submissions must be licensed under the GNU Lesser General Public License v3.
 
 Please read CONTRIBUTING.md for important guidelines to follow.
-
-Links
------
-
-* [WorldEdit repo](https://github.com/sk89q/worldedit)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,6 @@ subprojects {
 
 // Paper 1.16 and below has a different classpath
 mapOf(
-        "spigot_v1_15_R2" to "1_15_r1",
         "spigot_v1_16_R3" to "1_16_r3"
 ).forEach { (projectName, dep) ->
     project(":$projectName") {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,7 +22,6 @@ rootProject.name = "worldedit-adapters"
 data class Ver(val minor: Int, val rel: String)
 
 listOf(
-    Ver(15, "2"),
     Ver(16, "3"),
     Ver(17, "1")
 )


### PR DESCRIPTION
The ASM version Spigot 1.15.2 provides doesn't support Java 15 or higher. Core components require Java 17 or newer, therefore we can drop 1.15.2 here.
I'm not strongly against deleting the module, however, if we require Java 18, we can simply stop shipping the legacy adapters jar and archive this repository.