### PR TITLE
chore: Rename output artifact

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,7 +17,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-rootProject.name = "worldedit-adapters"
+rootProject.name = "fastasyncworldedit-adapters"
 
 data class Ver(val minor: Int, val rel: String)
 


### PR DESCRIPTION
#Rename the output artifact to improve matching with the origin project, which isn't WorldEdit, opposed to the name the jar has.